### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,8 @@
 name: Go
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/GalacticBonsai/MTGSim/security/code-scanning/1](https://github.com/GalacticBonsai/MTGSim/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only performs basic CI tasks (checking out code, setting up Go, installing dependencies, and running tests), it requires minimal permissions. The `contents: read` permission is sufficient for these tasks. The `permissions` block should be added at the root level of the workflow to apply to all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
