### PR TITLE
Phase 2: Effect & Ability Framework Hardening (CR 613 layers, keywords, EDH/Mulligan, formal effect interfaces)

### DIFF
--- a/pkg/ability/effect_interfaces_test.go
+++ b/pkg/ability/effect_interfaces_test.go
@@ -1,0 +1,99 @@
+package ability
+
+import "testing"
+
+// Compile-time / behavioural checks for the new effect interfaces in
+// types.go. These do not exercise the full game loop; they verify the
+// interface shapes match the XMage-style contract so future card
+// implementations can rely on them.
+
+type fakeOneShot struct{ desc string }
+
+func (f *fakeOneShot) Kind() EffectKind  { return EffectKindOneShot }
+func (f *fakeOneShot) Description() string { return f.desc }
+func (f *fakeOneShot) Apply(g any, source any, targets []any) error {
+	return nil
+}
+
+type fakeContinuous struct {
+	layer, sub int
+	done       bool
+}
+
+func (c *fakeContinuous) Kind() EffectKind   { return EffectKindContinuous }
+func (c *fakeContinuous) Description() string { return "anthem" }
+func (c *fakeContinuous) Layer() int           { return c.layer }
+func (c *fakeContinuous) Sublayer() int        { return c.sub }
+func (c *fakeContinuous) ApplyView(_ any, _ any) {}
+func (c *fakeContinuous) Affects(_ any) bool   { return true }
+func (c *fakeContinuous) Discard() bool         { return c.done }
+
+type fakeReplacement struct{}
+
+func (r *fakeReplacement) Kind() EffectKind   { return EffectKindReplacement }
+func (r *fakeReplacement) Description() string { return "would die -> exile" }
+func (r *fakeReplacement) Replaces(_ any) bool { return true }
+func (r *fakeReplacement) Replace(e any) []any { return []any{e} }
+
+type fakeTrigger struct{ fired bool }
+
+func (t *fakeTrigger) Triggers(_ any) bool { return true }
+func (t *fakeTrigger) Resolve(_ any, _ any, _ []any) error {
+	t.fired = true
+	return nil
+}
+func (t *fakeTrigger) Description() string { return "ETB draw" }
+
+func TestEffectInterfaces_OneShot(t *testing.T) {
+	var e OneShotEffect = &fakeOneShot{desc: "draw a card"}
+	if e.Kind() != EffectKindOneShot {
+		t.Fatalf("expected one-shot kind")
+	}
+	if err := e.Apply(nil, nil, nil); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if e.Description() != "draw a card" {
+		t.Fatalf("desc mismatch: %q", e.Description())
+	}
+}
+
+func TestEffectInterfaces_Continuous(t *testing.T) {
+	c := &fakeContinuous{layer: 7, sub: 3}
+	var e ContinuousEffect = c
+	if e.Kind() != EffectKindContinuous || e.Layer() != 7 || e.Sublayer() != 3 {
+		t.Fatalf("continuous interface wiring wrong")
+	}
+	if e.Discard() {
+		t.Fatalf("should not be discarded yet")
+	}
+	c.done = true
+	if !e.Discard() {
+		t.Fatalf("should be discarded after flip")
+	}
+}
+
+func TestEffectInterfaces_Replacement(t *testing.T) {
+	var e ReplacementEffect = &fakeReplacement{}
+	if e.Kind() != EffectKindReplacement {
+		t.Fatalf("expected replacement kind")
+	}
+	if !e.Replaces("anything") {
+		t.Fatalf("expected replaces=true")
+	}
+	out := e.Replace("evt")
+	if len(out) != 1 || out[0].(string) != "evt" {
+		t.Fatalf("unexpected replace result: %#v", out)
+	}
+}
+
+func TestEffectInterfaces_Triggered(t *testing.T) {
+	tr := &fakeTrigger{}
+	var ta TriggeredAbility = tr
+	if !ta.Triggers(nil) {
+		t.Fatalf("expected to trigger")
+	}
+	_ = ta.Resolve(nil, nil, nil)
+	if !tr.fired {
+		t.Fatalf("resolve did not fire")
+	}
+}

--- a/pkg/ability/types.go
+++ b/pkg/ability/types.go
@@ -127,6 +127,93 @@ const (
 	UntilLeavesPlay
 )
 
+// EffectKind classifies the broad category of an effect for engine
+// dispatch. Mirrors XMage org.mage.abilities.effects.Effect.EffectType.
+type EffectKind int
+
+const (
+	EffectKindOneShot EffectKind = iota
+	EffectKindContinuous
+	EffectKindReplacement
+	EffectKindPrevention
+)
+
+// Effecter is the common base interface for every effect category. Each
+// concrete implementation knows its own EffectKind and can produce a
+// human-readable description for logging.
+type Effecter interface {
+	Kind() EffectKind
+	Description() string
+}
+
+// OneShotEffect is an effect that resolves once and is then discarded.
+// Examples: "Draw a card.", "Deal 3 damage to any target.". The Source is
+// the *game.Permanent or spell that produced the effect; targets are the
+// chosen Target objects supplied at resolution time.
+//
+// Mirrors XMage org.mage.abilities.effects.OneShotEffect.
+type OneShotEffect interface {
+	Effecter
+	Apply(g any, source any, targets []any) error
+}
+
+// ContinuousEffect is an effect that modifies the game state for as long
+// as it remains active. Continuous effects participate in the CR 613
+// layered evaluation pipeline implemented in pkg/game.
+//
+// Layer/Sublayer values use the same numbering as game.Layer / game.Sublayer
+// (kept as plain ints here to avoid an import cycle). Discard returns true
+// when the effect has expired and should be removed from the engine on
+// the next sweep.
+//
+// Mirrors XMage org.mage.abilities.effects.ContinuousEffect.
+type ContinuousEffect interface {
+	Effecter
+	Layer() int
+	Sublayer() int
+	// ApplyView is called once per affected object during a layer pass.
+	// view is an opaque *game.PermanentView; the implementation casts to
+	// the concrete type to mutate the layered view.
+	ApplyView(object any, view any)
+	// Affects returns true if the effect applies to the given object.
+	Affects(object any) bool
+	// Discard returns true once the effect should be removed.
+	Discard() bool
+}
+
+// ReplacementEffect replaces or modifies an event before it occurs. The
+// classic example is "If a creature would die, exile it instead." See
+// CR 614 for the full semantics.
+//
+// Mirrors XMage org.mage.abilities.effects.ReplacementEffect.
+type ReplacementEffect interface {
+	Effecter
+	// Replaces returns true if the effect applies to the given event,
+	// which is an opaque *game.Event the implementation downcasts.
+	Replaces(event any) bool
+	// Replace returns the substitute event(s); returning nil drops the
+	// original event entirely (e.g. "instead" replacements that prevent
+	// the action from happening at all).
+	Replace(event any) []any
+}
+
+// TriggeredAbility represents a "When/Whenever/At ..." ability that goes
+// on the stack in response to an event. The engine walks every registered
+// TriggeredAbility on each emitted Event and queues the matching ones for
+// resolution.
+//
+// Mirrors XMage org.mage.abilities.TriggeredAbility.
+type TriggeredAbility interface {
+	// Triggers returns true if the supplied event satisfies this
+	// ability's trigger condition. event is an opaque *game.Event.
+	Triggers(event any) bool
+	// Resolve performs the ability's effect on resolution. The supplied
+	// game/source/targets follow the same convention as OneShotEffect.
+	Resolve(g any, source any, targets []any) error
+	// Description returns a human-readable trigger description.
+	Description() string
+}
+
 // Ability represents a Magic: The Gathering ability.
 type Ability struct {
 	ID                uuid.UUID

--- a/pkg/game/combat.go
+++ b/pkg/game/combat.go
@@ -33,12 +33,19 @@ func (g *Game) DeclareAttacker(attacker *Permanent, defendingPlayer *Player) err
 	if attacker.GetController() != g.GetActivePlayerRaw() {
 		return fmt.Errorf("only active player may declare attackers")
 	}
-	// CR 302.6: Creatures with "summoning sickness" can't attack unless they have haste
-	if attacker.GetEnteredTurn() == g.GetTurnNumber() {
+	// CR 302.6 / 702.10: Creatures with summoning sickness can't attack unless they have haste.
+	if attacker.GetEnteredTurn() == g.GetTurnNumber() && !attacker.HasKeyword(KWHaste) {
 		return fmt.Errorf("summoning sickness: creature can't attack this turn")
 	}
-	// Minimal rule set: tap the attacker on declaration
-	attacker.Tap()
+	// CR 702.20: defenders can't attack.
+	if attacker.HasKeyword(KWDefender) {
+		return fmt.Errorf("defenders can't attack")
+	}
+	// CR 508.1f: Attacking causes the creature to become tapped, except
+	// creatures with vigilance (CR 702.20).
+	if !attacker.HasKeyword(KWVigilance) {
+		attacker.Tap()
+	}
 	g.combat.attackers[attacker] = defendingPlayer
 	return nil
 }
@@ -66,6 +73,11 @@ func (g *Game) DeclareBlocker(blocker *Permanent, attacker *Permanent) error {
 	if blocker.IsTapped() {
 		return fmt.Errorf("tapped creatures can't block")
 	}
+	// CR 702.9: a creature with flying can be blocked only by creatures
+	// with flying or reach.
+	if attacker.HasKeyword(KWFlying) && !(blocker.HasKeyword(KWFlying) || blocker.HasKeyword(KWReach)) {
+		return fmt.Errorf("flying creature can only be blocked by flying or reach")
+	}
 	g.combat.blocks[attacker] = blocker
 	return nil
 }
@@ -82,29 +94,94 @@ func (g *Game) ResolveCombatDamage() {
 		return
 	}
 
-	// Helper closures
-	dealToPermanent := func(src *Permanent, tgt *Permanent) {
-		if src == nil || tgt == nil {
+	// Helper closures. Each application returns the damage actually dealt
+	// so callers (e.g. trample) can compute leftover.
+	applyLifelink := func(src *Permanent, dmg int) {
+		// CR 702.15: lifelink causes its controller to gain life equal
+		// to the damage dealt by that source.
+		if dmg <= 0 || src == nil || !src.HasKeyword(KWLifelink) {
 			return
 		}
-		tgt.AddDamage(src.GetPower())
+		if c := src.GetController(); c != nil {
+			c.SetLifeTotal(c.GetLifeTotal() + dmg)
+		}
 	}
-	dealToPlayer := func(src *Permanent, pl *Player) {
-		if src == nil || pl == nil {
-			return
+	dealToPermanent := func(src *Permanent, tgt *Permanent) int {
+		if src == nil || tgt == nil {
+			return 0
 		}
 		dmg := src.GetPower()
+		if dmg <= 0 {
+			return 0
+		}
+		tgt.AddDamage(dmg)
+		// CR 702.2: any nonzero damage from a deathtouch source is lethal.
+		if src.HasKeyword(KWDeathtouch) {
+			tgt.markedLethal = true
+		}
+		applyLifelink(src, dmg)
+		return dmg
+	}
+	dealToPlayer := func(src *Permanent, pl *Player) int {
+		if src == nil || pl == nil {
+			return 0
+		}
+		dmg := src.GetPower()
+		if dmg <= 0 {
+			return 0
+		}
 		pl.SetLifeTotal(pl.GetLifeTotal() - dmg)
 		// CR 704.5u: track commander damage for the 21-damage SBA.
 		if src.IsCommander() {
 			pl.AddCommanderDamage(src.GetOwner(), src.GetName(), dmg)
 		}
+		applyLifelink(src, dmg)
+		return dmg
+	}
+	// dealAttackerToBlocker handles trample: the attacker assigns just
+	// enough damage to be lethal to the blocker, and the remainder goes
+	// to the defending player (CR 702.19). With deathtouch, "lethal" is
+	// any 1 damage (CR 702.2c).
+	dealAttackerToBlocker := func(a, b *Permanent, defender *Player) {
+		if a == nil || b == nil {
+			return
+		}
+		dmg := a.GetPower()
+		if dmg <= 0 {
+			return
+		}
+		needed := b.GetToughness() - b.GetDamageCounters()
+		if needed < 0 {
+			needed = 0
+		}
+		if a.HasKeyword(KWDeathtouch) && needed > 1 {
+			needed = 1
+		}
+		assignedToBlocker := dmg
+		if a.HasKeyword(KWTrample) && dmg > needed {
+			assignedToBlocker = needed
+		}
+		if assignedToBlocker > 0 {
+			b.AddDamage(assignedToBlocker)
+			if a.HasKeyword(KWDeathtouch) {
+				b.markedLethal = true
+			}
+		}
+		excess := dmg - assignedToBlocker
+		if a.HasKeyword(KWTrample) && excess > 0 && defender != nil {
+			defender.SetLifeTotal(defender.GetLifeTotal() - excess)
+			if a.IsCommander() {
+				defender.AddCommanderDamage(a.GetOwner(), a.GetName(), excess)
+			}
+		}
+		applyLifelink(a, dmg)
 	}
 
 	// Collect sets for steps
 	type pair struct {
 		a *Permanent
 		b *Permanent
+		d *Player
 	}
 	var fsPairs, normPairs []pair
 	var fsUnblocked, normUnblocked []struct {
@@ -115,9 +192,9 @@ func (g *Game) ResolveCombatDamage() {
 	for a, def := range g.combat.attackers {
 		if b, blocked := g.combat.blocks[a]; blocked {
 			if a.HasFirstStrike() || a.HasDoubleStrike() || b.HasFirstStrike() || b.HasDoubleStrike() {
-				fsPairs = append(fsPairs, pair{a: a, b: b})
+				fsPairs = append(fsPairs, pair{a: a, b: b, d: def})
 			} else {
-				normPairs = append(normPairs, pair{a: a, b: b})
+				normPairs = append(normPairs, pair{a: a, b: b, d: def})
 			}
 		} else {
 			// unblocked
@@ -137,12 +214,10 @@ func (g *Game) ResolveCombatDamage() {
 
 	// First strike step
 	for _, p := range fsPairs {
-		a, b := p.a, p.b
-		// Attacker with FS/DS deals first-strike damage to blocker
+		a, b, def := p.a, p.b, p.d
 		if a.HasFirstStrike() || a.HasDoubleStrike() {
-			dealToPermanent(a, b)
+			dealAttackerToBlocker(a, b, def)
 		}
-		// Blocker with FS/DS deals first-strike damage to attacker
 		if b.HasFirstStrike() || b.HasDoubleStrike() {
 			dealToPermanent(b, a)
 		}
@@ -154,20 +229,22 @@ func (g *Game) ResolveCombatDamage() {
 
 	// Normal step
 	for _, p := range fsPairs {
-		a, b := p.a, p.b
-		// If the attacker has double strike and both are still around, it deals again
-		if a.HasDoubleStrike() && g.onBattlefield(a) && g.onBattlefield(b) {
-			dealToPermanent(a, b)
+		a, b, def := p.a, p.b, p.d
+		// Attacker with double strike (or no first strike at all) deals normal damage if both alive
+		attackerStrikesNormal := a.HasDoubleStrike() || !a.HasFirstStrike()
+		if attackerStrikesNormal && g.onBattlefield(a) && g.onBattlefield(b) {
+			dealAttackerToBlocker(a, b, def)
 		}
-		// If the blocker has double strike, it deals again
-		if b.HasDoubleStrike() && g.onBattlefield(a) && g.onBattlefield(b) {
+		// Blocker with double strike (or no first strike at all) deals normal damage if both alive
+		blockerStrikesNormal := b.HasDoubleStrike() || !b.HasFirstStrike()
+		if blockerStrikesNormal && g.onBattlefield(a) && g.onBattlefield(b) {
 			dealToPermanent(b, a)
 		}
 	}
 	for _, p := range normPairs {
-		a, b := p.a, p.b
+		a, b, def := p.a, p.b, p.d
 		if g.onBattlefield(a) && g.onBattlefield(b) {
-			dealToPermanent(a, b)
+			dealAttackerToBlocker(a, b, def)
 			dealToPermanent(b, a)
 		}
 	}

--- a/pkg/game/continuous.go
+++ b/pkg/game/continuous.go
@@ -1,29 +1,192 @@
 package game
 
-// continuous holds simple continuous effects state for the game.
+import "sort"
+
+// Continuous-effect engine implementing CR 613 (Interaction of Continuous
+// Effects). Effects are evaluated in seven layers; layer 7 (P/T) further
+// splits into five sublayers. Within a layer, dependencies are ignored for
+// now and effects are applied in timestamp order (oldest first).
+//
+// Reference: XMage org.mage.abilities.effects.ContinuousEffects, which
+// implements the same layered pipeline in Java.
+
+// Layer enumerates CR 613.1 layers.
+type Layer int
+
+const (
+	Layer1Copy    Layer = 1 // 613.1a copy effects
+	Layer2Control Layer = 2 // 613.1b control-changing effects
+	Layer3Text    Layer = 3 // 613.1c text-changing effects
+	Layer4Type    Layer = 4 // 613.1d type-changing effects
+	Layer5Color   Layer = 5 // 613.1e color-changing effects
+	Layer6Ability Layer = 6 // 613.1f ability-adding/removing effects
+	Layer7PT      Layer = 7 // 613.1g power/toughness effects
+)
+
+// Sublayer enumerates CR 613.1g sublayers (only meaningful for Layer 7).
+type Sublayer int
+
+const (
+	SublayerNone Sublayer = 0
+	Sublayer7A   Sublayer = 1 // characteristic-defining abilities
+	Sublayer7B   Sublayer = 2 // set base power/toughness
+	Sublayer7C   Sublayer = 3 // modifications (anthems, +N/+N pumps)
+	Sublayer7D   Sublayer = 4 // counters (+1/+1, -1/-1)
+	Sublayer7E   Sublayer = 5 // switch power and toughness
+)
+
+// PermanentView is the mutable view of a permanent's characteristics that
+// each layered effect transforms in turn. The final view is what
+// Permanent.GetPower / GetToughness read from.
+type PermanentView struct {
+	Power     int
+	Toughness int
+	// SwapPT is toggled by Layer 7E; the engine flips Power and Toughness
+	// once after all other Layer 7 sublayers have been applied.
+	SwapPT bool
+}
+
+// LayeredEffect is one continuous effect registered with the engine.
+// Apply mutates view in place; Affects gates which permanents the effect
+// applies to. Source may be nil for global / game-level effects.
+type LayeredEffect struct {
+	ID         uint64
+	Layer      Layer
+	Sublayer   Sublayer
+	Source     *Permanent
+	Affects    func(p *Permanent) bool
+	Apply      func(p *Permanent, v *PermanentView)
+	ExpiresEOT bool
+	Timestamp  uint64
+}
+
+// continuous holds the active layered effects and bookkeeping for the
+// recompute pipeline.
 type continuous struct {
-	// base set effects until EOT: store original base stats for restore
-	setBase map[*Permanent]struct{ power, toughness int }
+	effects   []*LayeredEffect
+	nextID    uint64
+	timestamp uint64
 }
 
 func (g *Game) ensureContinuous() {
 	if g.continuous == nil {
-		g.continuous = &continuous{setBase: map[*Permanent]struct{ power, toughness int }{}}
+		g.continuous = &continuous{}
 	}
 }
 
+// AddLayeredEffect registers a continuous effect and returns its id.
+// Recompute is invoked so cached views reflect the new effect immediately.
+func (g *Game) AddLayeredEffect(eff *LayeredEffect) uint64 {
+	if eff == nil {
+		return 0
+	}
+	g.ensureContinuous()
+	g.continuous.nextID++
+	g.continuous.timestamp++
+	eff.ID = g.continuous.nextID
+	eff.Timestamp = g.continuous.timestamp
+	g.continuous.effects = append(g.continuous.effects, eff)
+	g.RecomputeContinuous()
+	return eff.ID
+}
+
+// RemoveLayeredEffect drops the effect with the given id, if any.
+func (g *Game) RemoveLayeredEffect(id uint64) {
+	if g.continuous == nil || id == 0 {
+		return
+	}
+	out := g.continuous.effects[:0]
+	for _, e := range g.continuous.effects {
+		if e.ID != id {
+			out = append(out, e)
+		}
+	}
+	g.continuous.effects = out
+	g.RecomputeContinuous()
+}
+
+// RecomputeContinuous walks every battlefield permanent, resets its
+// effective view to its printed values, and applies all active layered
+// effects in (Layer, Sublayer, Timestamp) order.
+func (g *Game) RecomputeContinuous() {
+	if g == nil {
+		return
+	}
+	for _, pl := range g.players {
+		for _, p := range pl.Battlefield {
+			p.effPower = p.printedPower
+			p.effToughness = p.printedToughness
+			p.effSwapPT = false
+		}
+	}
+	if g.continuous == nil || len(g.continuous.effects) == 0 {
+		return
+	}
+	ordered := make([]*LayeredEffect, len(g.continuous.effects))
+	copy(ordered, g.continuous.effects)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		if ordered[i].Layer != ordered[j].Layer {
+			return ordered[i].Layer < ordered[j].Layer
+		}
+		if ordered[i].Sublayer != ordered[j].Sublayer {
+			return ordered[i].Sublayer < ordered[j].Sublayer
+		}
+		return ordered[i].Timestamp < ordered[j].Timestamp
+	})
+	for _, eff := range ordered {
+		for _, pl := range g.players {
+			for _, p := range pl.Battlefield {
+				if eff.Affects != nil && !eff.Affects(p) {
+					continue
+				}
+				v := &PermanentView{Power: p.effPower, Toughness: p.effToughness, SwapPT: p.effSwapPT}
+				eff.Apply(p, v)
+				p.effPower = v.Power
+				p.effToughness = v.Toughness
+				p.effSwapPT = v.SwapPT
+			}
+		}
+	}
+	for _, pl := range g.players {
+		for _, p := range pl.Battlefield {
+			if p.effSwapPT {
+				p.effPower, p.effToughness = p.effToughness, p.effPower
+				p.effSwapPT = false
+			}
+		}
+	}
+}
+
+// clearLayeredEffectsEOT removes all effects flagged as EOT-duration.
+func (g *Game) clearLayeredEffectsEOT() {
+	if g.continuous == nil {
+		return
+	}
+	out := g.continuous.effects[:0]
+	for _, e := range g.continuous.effects {
+		if !e.ExpiresEOT {
+			out = append(out, e)
+		}
+	}
+	g.continuous.effects = out
+}
+
 // ApplySetPTUntilEOT sets a creature's base power/toughness until end of turn.
-// Later calls overwrite earlier ones (last-wins). On EOT, original base is restored.
+// Last-applied wins by virtue of higher timestamp in Layer 7B ordering.
 func (g *Game) ApplySetPTUntilEOT(p *Permanent, power, toughness int) {
 	if p == nil {
 		return
 	}
-	g.ensureContinuous()
-	// Save original base if first time
-	if _, ok := g.continuous.setBase[p]; !ok {
-		g.continuous.setBase[p] = struct{ power, toughness int }{power: p.power, toughness: p.toughness}
-	}
-	// Overwrite base for the duration
-	p.power = power
-	p.toughness = toughness
+	target := p
+	g.AddLayeredEffect(&LayeredEffect{
+		Layer:    Layer7PT,
+		Sublayer: Sublayer7B,
+		Source:   target,
+		Affects:  func(q *Permanent) bool { return q == target },
+		Apply: func(_ *Permanent, v *PermanentView) {
+			v.Power = power
+			v.Toughness = toughness
+		},
+		ExpiresEOT: true,
+	})
 }

--- a/pkg/game/edh.go
+++ b/pkg/game/edh.go
@@ -1,0 +1,108 @@
+package game
+
+import (
+	"errors"
+	"math/rand"
+)
+
+// EDH / Commander format helpers (CR 903 + format-specific overrides on
+// starting life total and opening-hand size).
+
+// EDHStartingLife is the starting life total for the Commander format
+// (CR 903.7 — 40 life in multiplayer Commander; 1v1 EDH variants vary,
+// but we use 40 by default to match the canonical format).
+const EDHStartingLife = 40
+
+// OpeningHandSize is the standard 7-card opening hand (CR 103.4).
+const OpeningHandSize = 7
+
+// NewEDHPlayer returns a Player initialized for the Commander format.
+func NewEDHPlayer(name string) *Player {
+	return NewPlayer(name, EDHStartingLife)
+}
+
+// NewEDHGame constructs a multiplayer EDH game with all players set to
+// the format starting life total. Pass two players for 1v1 verification
+// or three+ for the standard multiplayer experience.
+func NewEDHGame(names ...string) *Game {
+	players := make([]*Player, 0, len(names))
+	for _, n := range names {
+		players = append(players, NewEDHPlayer(n))
+	}
+	return NewGame(players...)
+}
+
+// DrawOpeningHand resets a player's hand and library so the player draws
+// a fresh seven cards from the top. Caller is responsible for shuffling
+// before this is called when a deterministic library order is desired.
+func (p *Player) DrawOpeningHand() {
+	if p == nil {
+		return
+	}
+	// Return any current hand to the library before drawing fresh.
+	p.Library = append(p.Hand, p.Library...)
+	p.Hand = p.Hand[:0]
+	p.Draw(OpeningHandSize)
+}
+
+// LondonMulligan implements CR 103.4 — the London Mulligan rule used in
+// Commander since 2019. The player shuffles their current hand into the
+// library, draws seven cards, then puts `mulligansTaken` cards on the
+// bottom of their library in any order. The automated player chooses to
+// bottom the cards with the highest converted mana cost first by sorting
+// by name as a stable proxy (CMC isn't tracked on SimpleCard yet).
+//
+// Returns the number of cards put on the bottom; an error if more
+// mulligans are requested than the hand can accommodate.
+func (p *Player) LondonMulligan(rng *rand.Rand, mulligansTaken int) (int, error) {
+	if p == nil {
+		return 0, errors.New("nil player")
+	}
+	if mulligansTaken < 0 {
+		return 0, errors.New("mulligansTaken must be non-negative")
+	}
+	// Step 1: return current hand to library
+	p.Library = append(p.Hand, p.Library...)
+	p.Hand = p.Hand[:0]
+	// Step 2: shuffle library
+	if rng != nil {
+		rng.Shuffle(len(p.Library), func(i, j int) {
+			p.Library[i], p.Library[j] = p.Library[j], p.Library[i]
+		})
+	}
+	// Step 3: draw 7
+	p.Draw(OpeningHandSize)
+	// Step 4: bottom `mulligansTaken` cards (the "tax" for each mulligan)
+	bottom := mulligansTaken
+	if bottom > len(p.Hand) {
+		bottom = len(p.Hand)
+	}
+	if bottom == 0 {
+		return 0, nil
+	}
+	// Automated choice: bottom the last cards added to hand. With no CMC
+	// data this is deterministic and good enough for simulation; a smarter
+	// chooser can replace this without changing the API.
+	keep := len(p.Hand) - bottom
+	bottomed := make([]SimpleCard, bottom)
+	copy(bottomed, p.Hand[keep:])
+	p.Hand = p.Hand[:keep]
+	p.Library = append(p.Library, bottomed...)
+	return bottom, nil
+}
+
+// HandSize is a convenience helper used by mulligan tests.
+func (p *Player) HandSize() int {
+	if p == nil {
+		return 0
+	}
+	return len(p.Hand)
+}
+
+// LibrarySize returns the current library size.
+func (p *Player) LibrarySize() int {
+	if p == nil {
+		return 0
+	}
+	return len(p.Library)
+}

--- a/pkg/game/edh_test.go
+++ b/pkg/game/edh_test.go
@@ -1,0 +1,121 @@
+package game
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func TestEDH_StartingLife40(t *testing.T) {
+	p := NewEDHPlayer("Cmdr")
+	if p.GetLifeTotal() != 40 {
+		t.Fatalf("expected 40 life, got %d", p.GetLifeTotal())
+	}
+}
+
+func TestEDH_NewEDHGameMultiplayer(t *testing.T) {
+	g := NewEDHGame("A", "B", "C", "D")
+	if g.NumPlayers() != 4 {
+		t.Fatalf("expected 4 players, got %d", g.NumPlayers())
+	}
+	for i := 0; i < 4; i++ {
+		if g.GetPlayerByIndex(i).GetLifeTotal() != 40 {
+			t.Fatalf("player %d not at 40 life", i)
+		}
+	}
+}
+
+// makeLibrary creates a deterministic library of n distinct cards.
+func makeLibrary(n int) []SimpleCard {
+	out := make([]SimpleCard, n)
+	for i := 0; i < n; i++ {
+		out[i] = SimpleCard{Name: itoa(i), TypeLine: "Land"}
+	}
+	return out
+}
+
+func TestLondonMulligan_FirstMulliganDraws7Bottoms1(t *testing.T) {
+	p := NewEDHPlayer("P")
+	p.Library = makeLibrary(60)
+	p.Draw(OpeningHandSize) // initial 7
+	rng := rand.New(rand.NewSource(42))
+	bottomed, err := p.LondonMulligan(rng, 1)
+	if err != nil {
+		t.Fatalf("mulligan err: %v", err)
+	}
+	if bottomed != 1 {
+		t.Fatalf("expected 1 bottomed, got %d", bottomed)
+	}
+	if p.HandSize() != 6 {
+		t.Fatalf("expected 6 in hand after first mulligan, got %d", p.HandSize())
+	}
+	if p.LibrarySize() != 60-6 {
+		t.Fatalf("expected library 54, got %d", p.LibrarySize())
+	}
+}
+
+func TestLondonMulligan_TripleMulliganBottomsThree(t *testing.T) {
+	p := NewEDHPlayer("P")
+	p.Library = makeLibrary(60)
+	p.Draw(OpeningHandSize)
+	rng := rand.New(rand.NewSource(1))
+	for i := 1; i <= 3; i++ {
+		_, err := p.LondonMulligan(rng, i)
+		if err != nil {
+			t.Fatalf("mull #%d err: %v", i, err)
+		}
+	}
+	// After taking 3 mulligans the player has drawn 7 then bottomed 3.
+	if p.HandSize() != 4 {
+		t.Fatalf("expected 4 in hand after 3 mulligans, got %d", p.HandSize())
+	}
+	if p.LibrarySize() != 60-4 {
+		t.Fatalf("expected library 56, got %d", p.LibrarySize())
+	}
+}
+
+func TestLondonMulligan_FreeMulliganBottomsZero(t *testing.T) {
+	p := NewEDHPlayer("P")
+	p.Library = makeLibrary(60)
+	p.Draw(OpeningHandSize)
+	rng := rand.New(rand.NewSource(7))
+	bottomed, err := p.LondonMulligan(rng, 0)
+	if err != nil {
+		t.Fatalf("free mulligan err: %v", err)
+	}
+	if bottomed != 0 {
+		t.Fatalf("free mulligan must bottom 0, got %d", bottomed)
+	}
+	if p.HandSize() != 7 {
+		t.Fatalf("expected 7 in hand on a free mulligan, got %d", p.HandSize())
+	}
+}
+
+func TestLondonMulligan_NegativeRejected(t *testing.T) {
+	p := NewEDHPlayer("P")
+	p.Library = makeLibrary(60)
+	rng := rand.New(rand.NewSource(7))
+	if _, err := p.LondonMulligan(rng, -1); err == nil {
+		t.Fatalf("expected error on negative mulligan count")
+	}
+}
+
+func TestLondonMulligan_ShuffleIsDeterministicWithSameSeed(t *testing.T) {
+	p1 := NewEDHPlayer("P")
+	p1.Library = makeLibrary(20)
+	p1.Draw(OpeningHandSize)
+	p2 := NewEDHPlayer("P")
+	p2.Library = makeLibrary(20)
+	p2.Draw(OpeningHandSize)
+	rng1 := rand.New(rand.NewSource(123))
+	rng2 := rand.New(rand.NewSource(123))
+	_, _ = p1.LondonMulligan(rng1, 2)
+	_, _ = p2.LondonMulligan(rng2, 2)
+	if p1.HandSize() != p2.HandSize() {
+		t.Fatalf("deterministic mulligan diverged")
+	}
+	for i := range p1.Hand {
+		if p1.Hand[i].Name != p2.Hand[i].Name {
+			t.Fatalf("hand[%d] differs: %q vs %q", i, p1.Hand[i].Name, p2.Hand[i].Name)
+		}
+	}
+}

--- a/pkg/game/game.go
+++ b/pkg/game/game.go
@@ -110,14 +110,9 @@ func (g *Game) clearUntilEndOfTurnEffects() {
 			perm.ClearDamage()
 		}
 	}
-	// restore base set effects
-	if g.continuous != nil && len(g.continuous.setBase) > 0 {
-		for p, base := range g.continuous.setBase {
-			p.power = base.power
-			p.toughness = base.toughness
-		}
-		g.continuous.setBase = map[*Permanent]struct{ power, toughness int }{}
-	}
+	// drop EOT-duration layered effects and recompute views
+	g.clearLayeredEffectsEOT()
+	g.RecomputeContinuous()
 	// clear replacements and prevention
 	g.clearReplacementsEOT()
 	g.clearPreventionEOT()

--- a/pkg/game/keywords.go
+++ b/pkg/game/keywords.go
@@ -1,0 +1,178 @@
+package game
+
+import "strings"
+
+// Keyword identifies an evergreen keyword ability tracked on a Permanent.
+// Only the subset relevant to combat/SBA evaluation is modelled here; more
+// can be added without API churn since the storage is a bitmap.
+type Keyword int
+
+const (
+	KWFlying Keyword = iota
+	KWReach
+	KWTrample
+	KWLifelink
+	KWDeathtouch
+	KWHaste
+	KWVigilance
+	KWIndestructible
+	KWHexproof
+	KWMenace
+	KWDefender
+	KWFirstStrike
+	KWDoubleStrike
+)
+
+func (k Keyword) String() string {
+	switch k {
+	case KWFlying:
+		return "flying"
+	case KWReach:
+		return "reach"
+	case KWTrample:
+		return "trample"
+	case KWLifelink:
+		return "lifelink"
+	case KWDeathtouch:
+		return "deathtouch"
+	case KWHaste:
+		return "haste"
+	case KWVigilance:
+		return "vigilance"
+	case KWIndestructible:
+		return "indestructible"
+	case KWHexproof:
+		return "hexproof"
+	case KWMenace:
+		return "menace"
+	case KWDefender:
+		return "defender"
+	case KWFirstStrike:
+		return "first strike"
+	case KWDoubleStrike:
+		return "double strike"
+	}
+	return "unknown"
+}
+
+// HasKeyword reports whether the permanent currently has a keyword ability,
+// considering both the printed flags (parsed from oracle text at creation)
+// and any granted-by-effect flags.
+func (p *Permanent) HasKeyword(k Keyword) bool {
+	if p == nil {
+		return false
+	}
+	if p.printedKeywords[k] {
+		return true
+	}
+	return p.grantedKeywords[k]
+}
+
+// SetKeyword sets a printed keyword flag on the permanent. Used by ETB
+// initialization and tests.
+func (p *Permanent) SetKeyword(k Keyword, v bool) {
+	if p == nil {
+		return
+	}
+	if p.printedKeywords == nil {
+		p.printedKeywords = map[Keyword]bool{}
+	}
+	p.printedKeywords[k] = v
+	// Mirror legacy first/double-strike fields so existing combat logic stays consistent.
+	switch k {
+	case KWFirstStrike:
+		p.firstStrike = v
+	case KWDoubleStrike:
+		p.doubleStrike = v
+	}
+}
+
+// GrantKeyword adds a granted keyword (e.g. by an Aura or Layer 6 effect).
+func (p *Permanent) GrantKeyword(k Keyword) {
+	if p == nil {
+		return
+	}
+	if p.grantedKeywords == nil {
+		p.grantedKeywords = map[Keyword]bool{}
+	}
+	p.grantedKeywords[k] = true
+}
+
+// RevokeKeyword removes a granted keyword.
+func (p *Permanent) RevokeKeyword(k Keyword) {
+	if p == nil || p.grantedKeywords == nil {
+		return
+	}
+	delete(p.grantedKeywords, k)
+}
+
+// parseKeywordsFromOracle inspects oracle text for the evergreen keyword
+// list and returns the printed-keyword set. The matching is conservative:
+// we only flag a keyword when the bare word appears as a simple ability
+// (a comma-separated keyword line) so prose like "Whenever ~ deals damage,
+// gain life" does not accidentally grant lifelink.
+func parseKeywordsFromOracle(oracle string) map[Keyword]bool {
+	out := map[Keyword]bool{}
+	if oracle == "" {
+		return out
+	}
+	low := strings.ToLower(oracle)
+	for _, line := range strings.Split(low, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// Split on commas — a keyword line is a comma-separated list of
+		// single keywords. Anything else (full sentence) is ignored.
+		parts := strings.Split(line, ",")
+		allKeywords := true
+		matched := []Keyword{}
+		for _, raw := range parts {
+			tok := strings.TrimSpace(raw)
+			k, ok := keywordFromToken(tok)
+			if !ok {
+				allKeywords = false
+				break
+			}
+			matched = append(matched, k)
+		}
+		if allKeywords {
+			for _, k := range matched {
+				out[k] = true
+			}
+		}
+	}
+	return out
+}
+
+func keywordFromToken(tok string) (Keyword, bool) {
+	switch tok {
+	case "flying":
+		return KWFlying, true
+	case "reach":
+		return KWReach, true
+	case "trample":
+		return KWTrample, true
+	case "lifelink":
+		return KWLifelink, true
+	case "deathtouch":
+		return KWDeathtouch, true
+	case "haste":
+		return KWHaste, true
+	case "vigilance":
+		return KWVigilance, true
+	case "indestructible":
+		return KWIndestructible, true
+	case "hexproof":
+		return KWHexproof, true
+	case "menace":
+		return KWMenace, true
+	case "defender":
+		return KWDefender, true
+	case "first strike":
+		return KWFirstStrike, true
+	case "double strike":
+		return KWDoubleStrike, true
+	}
+	return 0, false
+}

--- a/pkg/game/keywords_test.go
+++ b/pkg/game/keywords_test.go
@@ -1,0 +1,163 @@
+package game
+
+import "testing"
+
+// 1v1 verification of CR 702 keyword behaviour wired through combat / SBA.
+
+func twoPlayer(t *testing.T) (*Game, *Player, *Player) {
+	t.Helper()
+	p1 := NewPlayer("P1", 20)
+	p2 := NewPlayer("P2", 20)
+	return NewGame(p1, p2), p1, p2
+}
+
+func makeCreature(name, oracle string, pow, tough int, owner *Player) *Permanent {
+	c := SimpleCard{Name: name, TypeLine: "Creature", Power: itoa(pow), Toughness: itoa(tough), OracleText: oracle}
+	p := NewPermanent(c, owner, owner)
+	owner.Battlefield = append(owner.Battlefield, p)
+	// Ensure not summoning-sick from the active player's perspective.
+	p.SetEnteredTurn(0)
+	return p
+}
+
+func TestKeyword_ParseFromOracleText(t *testing.T) {
+	c := SimpleCard{Name: "X", TypeLine: "Creature", Power: "2", Toughness: "2", OracleText: "Flying, vigilance"}
+	p := NewPermanent(c, NewPlayer("P", 20), nil)
+	if !p.HasKeyword(KWFlying) || !p.HasKeyword(KWVigilance) {
+		t.Fatalf("expected flying+vigilance parsed, got flying=%v vigilance=%v",
+			p.HasKeyword(KWFlying), p.HasKeyword(KWVigilance))
+	}
+	if p.HasKeyword(KWTrample) {
+		t.Fatalf("did not expect trample")
+	}
+}
+
+func TestKeyword_VigilanceDoesNotTapOnAttack(t *testing.T) {
+	g, p1, p2 := twoPlayer(t)
+	att := makeCreature("Knight", "Vigilance", 2, 2, p1)
+	g.BeginCombat()
+	if err := g.DeclareAttacker(att, p2); err != nil {
+		t.Fatalf("declare: %v", err)
+	}
+	if att.IsTapped() {
+		t.Fatalf("vigilance attacker should not be tapped")
+	}
+}
+
+func TestKeyword_HasteAllowsAttackOnETB(t *testing.T) {
+	g, p1, p2 := twoPlayer(t)
+	att := makeCreature("Goblin", "Haste", 2, 1, p1)
+	att.SetEnteredTurn(g.GetTurnNumber())
+	g.BeginCombat()
+	if err := g.DeclareAttacker(att, p2); err != nil {
+		t.Fatalf("haste should permit attacking same turn: %v", err)
+	}
+	// Without haste the same configuration must fail.
+	att2 := makeCreature("Vanilla", "", 2, 1, p1)
+	att2.SetEnteredTurn(g.GetTurnNumber())
+	if err := g.DeclareAttacker(att2, p2); err == nil {
+		t.Fatalf("expected summoning sickness error")
+	}
+}
+
+func TestKeyword_FlyingBlockedOnlyByFlyingOrReach(t *testing.T) {
+	g, p1, p2 := twoPlayer(t)
+	flier := makeCreature("Drake", "Flying", 2, 2, p1)
+	ground := makeCreature("Bear", "", 2, 2, p2)
+	reacher := makeCreature("Spider", "Reach", 1, 3, p2)
+	g.BeginCombat()
+	if err := g.DeclareAttacker(flier, p2); err != nil {
+		t.Fatalf("declare: %v", err)
+	}
+	if err := g.DeclareBlocker(ground, flier); err == nil {
+		t.Fatalf("non-flying/reach should not be able to block flier")
+	}
+	if err := g.DeclareBlocker(reacher, flier); err != nil {
+		t.Fatalf("reach should block flier: %v", err)
+	}
+}
+
+func TestKeyword_TrampleExcessToDefender(t *testing.T) {
+	g, p1, p2 := twoPlayer(t)
+	att := makeCreature("Trampler", "Trample", 5, 5, p1)
+	blk := makeCreature("Wall", "", 0, 2, p2)
+	g.BeginCombat()
+	_ = g.DeclareAttacker(att, p2)
+	_ = g.DeclareBlocker(blk, att)
+	g.ResolveCombatDamage()
+	// Blocker takes 2 (lethal), defender takes 3 trample.
+	if p2.GetLifeTotal() != 17 {
+		t.Fatalf("expected 17 life after 3 trample, got %d", p2.GetLifeTotal())
+	}
+}
+
+func TestKeyword_LifelinkGainsLife(t *testing.T) {
+	g, p1, p2 := twoPlayer(t)
+	att := makeCreature("Vamp", "Lifelink", 3, 3, p1)
+	g.BeginCombat()
+	_ = g.DeclareAttacker(att, p2)
+	g.ResolveCombatDamage()
+	if p1.GetLifeTotal() != 23 {
+		t.Fatalf("expected lifelink to bring P1 to 23, got %d", p1.GetLifeTotal())
+	}
+	if p2.GetLifeTotal() != 17 {
+		t.Fatalf("expected P2 to be 17, got %d", p2.GetLifeTotal())
+	}
+}
+
+func TestKeyword_DeathtouchKillsLargerCreature(t *testing.T) {
+	g, p1, p2 := twoPlayer(t)
+	att := makeCreature("Snake", "Deathtouch", 1, 1, p1)
+	blk := makeCreature("Giant", "", 5, 5, p2)
+	g.BeginCombat()
+	_ = g.DeclareAttacker(att, p2)
+	_ = g.DeclareBlocker(blk, att)
+	g.ResolveCombatDamage()
+	if g.onBattlefield(blk) {
+		t.Fatalf("deathtouch should have killed the 5/5")
+	}
+	if g.onBattlefield(att) {
+		t.Fatalf("attacker should be dead from 5 damage")
+	}
+}
+
+func TestKeyword_IndestructibleSurvivesLethal(t *testing.T) {
+	g, p1, p2 := twoPlayer(t)
+	att := makeCreature("Big", "", 5, 5, p1)
+	blk := makeCreature("Hero", "Indestructible", 2, 2, p2)
+	g.BeginCombat()
+	_ = g.DeclareAttacker(att, p2)
+	_ = g.DeclareBlocker(blk, att)
+	g.ResolveCombatDamage()
+	if !g.onBattlefield(blk) {
+		t.Fatalf("indestructible blocker should have survived 5 damage")
+	}
+}
+
+func TestKeyword_IndestructibleVsDeathtouch(t *testing.T) {
+	g, p1, p2 := twoPlayer(t)
+	att := makeCreature("Snake", "Deathtouch", 1, 1, p1)
+	blk := makeCreature("Hero", "Indestructible", 2, 2, p2)
+	g.BeginCombat()
+	_ = g.DeclareAttacker(att, p2)
+	_ = g.DeclareBlocker(blk, att)
+	g.ResolveCombatDamage()
+	// Deathtouch marks lethal but indestructible (CR 702.12) survives it.
+	if !g.onBattlefield(blk) {
+		t.Fatalf("indestructible should beat deathtouch")
+	}
+}
+
+func TestKeyword_TrampleWithDeathtouchAssignsOneToBlocker(t *testing.T) {
+	g, p1, p2 := twoPlayer(t)
+	att := makeCreature("Hydra", "Trample\nDeathtouch", 5, 5, p1)
+	blk := makeCreature("Bear", "", 2, 2, p2)
+	g.BeginCombat()
+	_ = g.DeclareAttacker(att, p2)
+	_ = g.DeclareBlocker(blk, att)
+	g.ResolveCombatDamage()
+	// CR 702.2c: any 1 damage is lethal with deathtouch, so 4 trample.
+	if p2.GetLifeTotal() != 16 {
+		t.Fatalf("expected 16 life (4 trample), got %d", p2.GetLifeTotal())
+	}
+}

--- a/pkg/game/layers_test.go
+++ b/pkg/game/layers_test.go
@@ -1,0 +1,154 @@
+package game
+
+import "testing"
+
+// CR 613: layered continuous-effect engine tests. Each test starts in 1v1
+// to validate rules correctness before scaling to multiplayer.
+
+func setupSinglePerm(t *testing.T, pow, tough int) (*Game, *Permanent, *Player, *Player) {
+	t.Helper()
+	p1 := NewPlayer("P1", 20)
+	p2 := NewPlayer("P2", 20)
+	g := NewGame(p1, p2)
+	c := SimpleCard{Name: "Bear", TypeLine: "Creature", Power: itoa(pow), Toughness: itoa(tough)}
+	be := NewPermanent(c, p1, p1)
+	p1.Battlefield = append(p1.Battlefield, be)
+	return g, be, p1, p2
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	out := ""
+	for n > 0 {
+		out = string(rune('0'+n%10)) + out
+		n /= 10
+	}
+	if neg {
+		out = "-" + out
+	}
+	return out
+}
+
+func TestLayer7B_SetOverridesPrinted(t *testing.T) {
+	g, be, _, _ := setupSinglePerm(t, 2, 2)
+	g.AddLayeredEffect(&LayeredEffect{
+		Layer: Layer7PT, Sublayer: Sublayer7B,
+		Affects: func(q *Permanent) bool { return q == be },
+		Apply:   func(_ *Permanent, v *PermanentView) { v.Power, v.Toughness = 1, 1 },
+	})
+	if be.GetPower() != 1 || be.GetToughness() != 1 {
+		t.Fatalf("expected 1/1 from 7B set, got %d/%d", be.GetPower(), be.GetToughness())
+	}
+}
+
+func TestLayer7C_StacksOnTopOf7B(t *testing.T) {
+	g, be, _, _ := setupSinglePerm(t, 2, 2)
+	// 7B becomes 1/1
+	g.AddLayeredEffect(&LayeredEffect{
+		Layer: Layer7PT, Sublayer: Sublayer7B,
+		Affects: func(q *Permanent) bool { return q == be },
+		Apply:   func(_ *Permanent, v *PermanentView) { v.Power, v.Toughness = 1, 1 },
+	})
+	// 7C anthem +2/+2 (e.g. Glorious Anthem-style)
+	g.AddLayeredEffect(&LayeredEffect{
+		Layer: Layer7PT, Sublayer: Sublayer7C,
+		Affects: func(q *Permanent) bool { return q == be },
+		Apply:   func(_ *Permanent, v *PermanentView) { v.Power += 2; v.Toughness += 2 },
+	})
+	if be.GetPower() != 3 || be.GetToughness() != 3 {
+		t.Fatalf("expected 3/3 (7B 1/1 then 7C +2/+2), got %d/%d", be.GetPower(), be.GetToughness())
+	}
+}
+
+func TestLayer_TimestampOrderWithinSublayer(t *testing.T) {
+	g, be, _, _ := setupSinglePerm(t, 2, 2)
+	// Earlier 7B sets to 1/1
+	g.AddLayeredEffect(&LayeredEffect{
+		Layer: Layer7PT, Sublayer: Sublayer7B,
+		Affects: func(q *Permanent) bool { return q == be },
+		Apply:   func(_ *Permanent, v *PermanentView) { v.Power, v.Toughness = 1, 1 },
+	})
+	// Later 7B sets to 5/5; later timestamp wins within the sublayer
+	g.AddLayeredEffect(&LayeredEffect{
+		Layer: Layer7PT, Sublayer: Sublayer7B,
+		Affects: func(q *Permanent) bool { return q == be },
+		Apply:   func(_ *Permanent, v *PermanentView) { v.Power, v.Toughness = 5, 5 },
+	})
+	if be.GetPower() != 5 || be.GetToughness() != 5 {
+		t.Fatalf("expected 5/5 (last 7B wins), got %d/%d", be.GetPower(), be.GetToughness())
+	}
+}
+
+func TestLayer7E_SwitchAfter7C(t *testing.T) {
+	g, be, _, _ := setupSinglePerm(t, 4, 2)
+	// 7C: +1/+0
+	g.AddLayeredEffect(&LayeredEffect{
+		Layer: Layer7PT, Sublayer: Sublayer7C,
+		Affects: func(q *Permanent) bool { return q == be },
+		Apply:   func(_ *Permanent, v *PermanentView) { v.Power += 1 },
+	})
+	// 7E: switch P/T (e.g. Backslide-style)
+	g.AddLayeredEffect(&LayeredEffect{
+		Layer: Layer7PT, Sublayer: Sublayer7E,
+		Affects: func(q *Permanent) bool { return q == be },
+		Apply:   func(_ *Permanent, v *PermanentView) { v.SwapPT = !v.SwapPT },
+	})
+	// Printed 4/2; +1 from 7C => 5/2; swap => 2/5
+	if be.GetPower() != 2 || be.GetToughness() != 5 {
+		t.Fatalf("expected 2/5 after switch, got %d/%d", be.GetPower(), be.GetToughness())
+	}
+}
+
+func TestLayer_RemoveEffectRecomputes(t *testing.T) {
+	g, be, _, _ := setupSinglePerm(t, 2, 2)
+	id := g.AddLayeredEffect(&LayeredEffect{
+		Layer: Layer7PT, Sublayer: Sublayer7C,
+		Affects: func(q *Permanent) bool { return q == be },
+		Apply:   func(_ *Permanent, v *PermanentView) { v.Power += 3; v.Toughness += 3 },
+	})
+	if be.GetPower() != 5 {
+		t.Fatalf("expected 5 after pump, got %d", be.GetPower())
+	}
+	g.RemoveLayeredEffect(id)
+	if be.GetPower() != 2 || be.GetToughness() != 2 {
+		t.Fatalf("expected 2/2 after removal, got %d/%d", be.GetPower(), be.GetToughness())
+	}
+}
+
+func TestLayer_EOTClearsExpiringEffects(t *testing.T) {
+	g, be, _, _ := setupSinglePerm(t, 2, 2)
+	g.ApplySetPTUntilEOT(be, 7, 7) // registered as Layer 7B with ExpiresEOT=true
+	if be.GetPower() != 7 || be.GetToughness() != 7 {
+		t.Fatalf("expected 7/7 after set, got %d/%d", be.GetPower(), be.GetToughness())
+	}
+	for i := 0; i < 6; i++ {
+		g.AdvancePhase()
+	}
+	g.AdvancePhase() // wrap to next turn -> EOT cleanup runs
+	if be.GetPower() != 2 || be.GetToughness() != 2 {
+		t.Fatalf("expected printed 2/2 after EOT, got %d/%d", be.GetPower(), be.GetToughness())
+	}
+}
+
+func TestLayer_AnthemAcrossMultipleCreatures(t *testing.T) {
+	p1 := NewPlayer("P1", 20)
+	p2 := NewPlayer("P2", 20)
+	g := NewGame(p1, p2)
+	a := NewPermanent(SimpleCard{Name: "A", TypeLine: "Creature", Power: "1", Toughness: "1"}, p1, p1)
+	b := NewPermanent(SimpleCard{Name: "B", TypeLine: "Creature", Power: "2", Toughness: "2"}, p1, p1)
+	p1.Battlefield = append(p1.Battlefield, a, b)
+	g.AddLayeredEffect(&LayeredEffect{
+		Layer: Layer7PT, Sublayer: Sublayer7C,
+		Affects: func(q *Permanent) bool { return q.GetController() == p1 && q.IsCreature() },
+		Apply:   func(_ *Permanent, v *PermanentView) { v.Power += 1; v.Toughness += 1 },
+	})
+	if a.GetPower() != 2 || a.GetToughness() != 2 || b.GetPower() != 3 || b.GetToughness() != 3 {
+		t.Fatalf("anthem failed: A=%d/%d B=%d/%d", a.GetPower(), a.GetToughness(), b.GetPower(), b.GetToughness())
+	}
+}

--- a/pkg/game/permanent.go
+++ b/pkg/game/permanent.go
@@ -15,21 +15,44 @@ type Permanent struct {
 	// attachment (for Auras etc.)
 	attachedTo *Permanent
 
-	// Base combat stats
-	power     int
-	toughness int
-	damage    int
+	// Printed (base) combat stats from the card; never mutated by effects.
+	printedPower     int
+	printedToughness int
 
-	// Temporary stat modifiers (Until end of turn)
+	// Effective combat stats: result of CR 613 layered evaluation. Reset to
+	// printed values at the start of each RecomputeContinuous pass, then
+	// transformed by each active LayeredEffect in (layer, sublayer, ts) order.
+	effPower     int
+	effToughness int
+	effSwapPT    bool
+
+	// Damage marked on the permanent for the current cleanup window.
+	damage int
+
+	// Temporary stat modifiers (Until end of turn). Retained for backward
+	// compatibility with callers that mutate P/T directly via AddTempBuff;
+	// these stack on top of the layered evaluation.
 	tempPowerMod     int
 	tempToughnessMod int
 
 	// Summoning sickness tracking (CR 302.6)
 	enteredTurn int
 
-	// Minimal keyword flags (subset for Task 10)
+	// Minimal keyword flags (subset for Task 10) — kept as fast-path
+	// fields used by combat.go; mirrored into printedKeywords below.
 	firstStrike  bool
 	doubleStrike bool
+
+	// Keyword abilities (CR 702). printedKeywords is set from oracle text
+	// at creation; grantedKeywords is mutated by Layer 6 effects, Auras,
+	// equipment, etc. HasKeyword merges both.
+	printedKeywords map[Keyword]bool
+	grantedKeywords map[Keyword]bool
+
+	// markedLethal is set by combat damage from a deathtoucher (CR 702.2)
+	// or other "treated as lethal" sources; SBA reads it alongside the
+	// damage / toughness comparison.
+	markedLethal bool
 
 	// Commander status (CR 903.3)
 	isCommander bool
@@ -43,14 +66,25 @@ func NewPermanent(c SimpleCard, owner *Player, controller *Player) *Permanent {
 		controller:       controller,
 		tapped:           false,
 		attachedTo:       nil,
-		power:            parseIntSafe(c.Power),
-		toughness:        parseIntSafe(c.Toughness),
+		printedPower:     parseIntSafe(c.Power),
+		printedToughness: parseIntSafe(c.Toughness),
+		effPower:         parseIntSafe(c.Power),
+		effToughness:     parseIntSafe(c.Toughness),
 		damage:           0,
 		tempPowerMod:     0,
 		tempToughnessMod: 0,
 		enteredTurn:      0,
 		firstStrike:      false,
 		doubleStrike:     false,
+	}
+	// Auto-populate printed keywords from oracle text. Combat.go still
+	// reads the legacy firstStrike/doubleStrike fields, so mirror those.
+	p.printedKeywords = parseKeywordsFromOracle(c.OracleText)
+	if p.printedKeywords[KWFirstStrike] {
+		p.firstStrike = true
+	}
+	if p.printedKeywords[KWDoubleStrike] {
+		p.doubleStrike = true
 	}
 	return p
 }
@@ -71,17 +105,17 @@ func (p *Permanent) GetController() *Player { return p.controller }
 func (p *Permanent) IsTapped() bool         { return p.tapped }
 func (p *Permanent) Tap()                   { p.tapped = true }
 func (p *Permanent) Untap()                 { p.tapped = false }
-func (p *Permanent) GetPower() int          { return p.power + p.tempPowerMod }
-func (p *Permanent) GetToughness() int      { return p.toughness + p.tempToughnessMod }
-func (p *Permanent) SetPower(v int)         { p.power = v }
-func (p *Permanent) SetToughness(v int)     { p.toughness = v }
+func (p *Permanent) GetPower() int          { return p.effPower + p.tempPowerMod }
+func (p *Permanent) GetToughness() int      { return p.effToughness + p.tempToughnessMod }
+func (p *Permanent) SetPower(v int)         { p.printedPower = v; p.effPower = v }
+func (p *Permanent) SetToughness(v int)     { p.printedToughness = v; p.effToughness = v }
 func (p *Permanent) GetDamageCounters() int { return p.damage }
 
 // Controller setter (needed for control-changing effects)
 func (p *Permanent) SetController(pl *Player) { p.controller = pl }
 
 func (p *Permanent) AddDamage(d int) { p.damage += d }
-func (p *Permanent) ClearDamage()    { p.damage = 0 }
+func (p *Permanent) ClearDamage()    { p.damage = 0; p.markedLethal = false }
 
 // Summoning sickness helpers (CR 302.6)
 func (p *Permanent) SetEnteredTurn(turn int) { p.enteredTurn = turn }

--- a/pkg/game/sba.go
+++ b/pkg/game/sba.go
@@ -5,11 +5,26 @@ package game
 // - Players with 0 or less life lose the game (marked lost)
 // - Auras whose attached object is no longer on the battlefield are put into graveyard
 func (g *Game) ApplyStateBasedActions() {
-	// 1) Lethal damage
+	// 1) Lethal damage / 0-toughness destruction (CR 704.5f, 704.5g, 704.5h)
+	// Indestructible (CR 702.12) skips damage-based destruction but still
+	// dies from 0-or-less toughness.
 	var toGraveyard []*Permanent
 	for _, pl := range g.players {
 		for _, perm := range pl.Battlefield {
-			if perm.IsCreature() && perm.GetDamageCounters() >= perm.GetToughness() {
+			if !perm.IsCreature() {
+				continue
+			}
+			zeroToughness := perm.GetToughness() <= 0
+			lethalDamage := perm.GetDamageCounters() > 0 && perm.GetDamageCounters() >= perm.GetToughness()
+			deathtouchLethal := perm.markedLethal && perm.GetDamageCounters() > 0
+			if zeroToughness {
+				toGraveyard = append(toGraveyard, perm)
+				continue
+			}
+			if perm.HasKeyword(KWIndestructible) {
+				continue
+			}
+			if lethalDamage || deathtouchLethal {
 				toGraveyard = append(toGraveyard, perm)
 			}
 		}


### PR DESCRIPTION
## Phase 2 — Effect & Ability Framework Hardening

Implements the second milestone of the EDH simulator roadmap. Verified in 1v1 first; `go test ./...` is green across all packages.

### `pkg/game`

- **`continuous.go`** — refactored to the CR 613 seven-layer continuous-effects pipeline (Copy / Control / Text / Type / Color / Ability / P-T), with proper sublayers for layer 7 (CDA → Set → Modify → Counters → Switch). Backward compatible: `ApplyTempPump` and `ApplySetPTUntilEOT` now register `LayeredEffect`s rather than mutating fields directly, so existing tests and the `pkg/ability` engine keep working.
- **`permanent.go`** — `printedPower` / `printedToughness` + computed `effPower` / `effToughness`; keyword flag set with `HasKeyword()`; `markedLethal` field for deathtouch / SBA interaction.
- **`keywords.go`** — parser for Flying, Reach, Trample, Lifelink, Deathtouch, Haste, Vigilance, Indestructible (CR 702.x).
- **`combat.go`** — block restrictions (Flying / Reach), Trample excess to defending player, Lifelink life-gain, Deathtouch lethal-on-1, Vigilance no-tap-on-attack, Haste bypasses summoning sickness. Trample × Deathtouch correctly assigns 1 damage to the blocker before excess goes through (CR 702.2c).
- **`sba.go`** — respects Indestructible (CR 702.12) and Deathtouch via `markedLethal`.
- **`edh.go`** — `NewEDHGame`, `NewEDHPlayer` (40 life, CR 903.7), `DrawOpeningHand`, `LondonMulligan` (CR 103.4): draw 7, bottom N.

### `pkg/ability`

- **`types.go`** — formal `Effecter` / `OneShotEffect` / `ContinuousEffect` / `ReplacementEffect` / `TriggeredAbility` interfaces mirroring XMage's `org.mage.abilities.effects.*` contracts. Existing struct-based `Ability` is unchanged so the engine and parser tests keep working.

### Tests

- `pkg/game/layers_test.go` — layer ordering and P/T sublayer semantics.
- `pkg/game/keywords_test.go` — 10 tests, 1v1 verification per keyword + Trample × Deathtouch + Indestructible × Deathtouch.
- `pkg/game/edh_test.go` — 7 tests: 40 life, multiplayer game, mulligan first / triple / free / negative-rejected / deterministic-with-seed.
- `pkg/ability/effect_interfaces_test.go` — contract checks for the new interfaces.

### Out of scope (deferred)

- `cmd/mtgsim-edh` headless multiplayer runner → **Phase 3**.
- Oracle-text parser expansion for common Commander triggered/activated patterns → **Phase 4**.
