### PR TITLE
Fix #66 CopySpell deep copy, #67 CantBlock check, close #60

### DIFF
--- a/pkg/ability/engine.go
+++ b/pkg/ability/engine.go
@@ -604,9 +604,23 @@ func (ee *ExecutionEngine) applyEffect(effect Effect, controller AbilityPlayer, 
 			stack := s.GetStack()
 			if stack.Size() > 0 {
 				top := stack.Peek()
-				if top != nil {
-					stack.AddSpell(top.Spell, controller, top.Targets)
-					logger.LogCard("Copied spell: %s", top.Description)
+				if top != nil && top.Spell != nil {
+					copyEffects := make([]Effect, len(top.Spell.Effects))
+					copy(copyEffects, top.Spell.Effects)
+					copyTargets := make([]interface{}, len(top.Targets))
+					copy(copyTargets, top.Targets)
+					copied := &Spell{
+						ID:         uuid.New(),
+						Name:       top.Spell.Name,
+						ManaCost:   top.Spell.ManaCost,
+						CMC:        top.Spell.CMC,
+						TypeLine:   top.Spell.TypeLine,
+						OracleText: top.Spell.OracleText,
+						Effects:    copyEffects,
+						Source:     top.Spell.Source,
+					}
+					stack.AddSpell(copied, controller, copyTargets)
+					logger.LogCard("Copied spell: %s (new ID: %s)", top.Spell.Name, copied.ID)
 				}
 			}
 		}

--- a/pkg/game/combat.go
+++ b/pkg/game/combat.go
@@ -76,6 +76,9 @@ func (g *Game) DeclareBlocker(blocker *Permanent, attacker *Permanent) error {
 	if blocker.IsTapped() {
 		return fmt.Errorf("tapped creatures can't block")
 	}
+	if blocker.CantBlock() {
+		return fmt.Errorf("creature can't block")
+	}
 	// CR 702.9: a creature with flying can be blocked only by creatures
 	// with flying or reach.
 	if attacker.HasKeyword(KWFlying) && !blocker.HasKeyword(KWFlying) && !blocker.HasKeyword(KWReach) {


### PR DESCRIPTION
**Fixes:**
- **Closes #66**: CopySpell now creates an independent Spell copy with new UUID, separate Effects/Targets slices, instead of sharing the same pointer (affects Fork, Reverberate, Twincast, etc.)
- **Closes #67**: Added CantBlock() check in DeclareBlocker - creatures with attack/block restrictions now properly can't block (affects Arrest, Pacifism, etc.)
- **Closes #60**: Closed as already fixed (NewPermanent stores source SimpleCard with OracleText preserved)

**Skipped for this batch:** #65 (ChooseMode - requires architectural work), #68 (combat damage - major rework), #71 (gatekeeper tuning)