### PR TITLE
Fix #64: Logging for unimplemented effect types

### DIFF
--- a/pkg/ability/engine.go
+++ b/pkg/ability/engine.go
@@ -694,6 +694,7 @@ func (ee *ExecutionEngine) applyEffect(effect Effect, controller AbilityPlayer, 
 		logger.LogCard("Reanimated %s from graveyard", reanimatedCard.Name)
 
 	default:
+		logger.LogCard("Unimplemented effect type during applyEffect: %v for %s", effect.Type, effect.Description)
 		return fmt.Errorf("unimplemented effect type: %v", effect.Type)
 	}
 


### PR DESCRIPTION
**Closes #64**

Default case in applyEffect now logs directly (in addition to returning an error which was already logged by callers), ensuring no code path silently swallows unimplemented effects.

**Remaining open issues requiring architectural work:**
- #65: ChooseMode modal spell selection — needs full mode parsing/storage
- #68: Combat damage rework — trample, first strike, protection, prevention
- #71: inferSupportedEffect gatekeeper — 5,673 cards rejected (root cause unknown without parser audit)
- #61: Trigger stack routing — CR 603.3 compliance