### PR TITLE
Fix #55: Batch declare attackers, close stale issues

### DIFF
--- a/pkg/simulation/edh_runner_steps.go
+++ b/pkg/simulation/edh_runner_steps.go
@@ -669,10 +669,10 @@ func runCombatPhase(g *game.Game, ap *game.Player, log *EDHEventLog, metrics *ed
 		}
 		if err := g.DeclareAttacker(perm, defender); err == nil {
 			declared++
-			if log != nil {
-				log.Append(EDHEvent{Turn: g.GetTurnNumber(), Phase: phaseName(game.PhaseCombat), Kind: EventAttackDeclared, Actor: ap.GetName(), Target: defender.GetName(), Detail: perm.GetName()})
-			}
 		}
+	}
+	if log != nil && declared > 0 {
+		log.Append(EDHEvent{Turn: g.GetTurnNumber(), Phase: phaseName(game.PhaseCombat), Kind: EventAttackDeclared, Actor: ap.GetName(), Target: defender.GetName(), Detail: intString(declared) + " attackers"})
 	}
 	g.ResolveCombatDamage()
 	damage := max(0, beforeLife-defender.GetLifeTotal())


### PR DESCRIPTION
**Closes #55**: Batch declare attackers — single `attack_declared` log event per combat (e.g., "12 attackers") instead of one per creature. Prevents O(n) event explosion from 400+ token attackers.

**Also closes:** #56, #57, #58 (stale issues — fixes were already applied in prior commits)